### PR TITLE
Fix: replace > with >= in PurchaseWithVirtualItem.checkTargetBalance

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Store/purchaseTypes/PurchaseWithVirtualItem.cs
+++ b/Soomla/Assets/Plugins/Soomla/Store/purchaseTypes/PurchaseWithVirtualItem.cs
@@ -119,7 +119,7 @@ namespace Soomla.Store
 		private bool checkTargetBalance (VirtualItem item)
 		{
 			int balance = item.GetBalance ();
-			return balance > Amount;
+			return balance >= Amount;
 		}
 	}
 }


### PR DESCRIPTION
Fixing PurchaseWithVirtualItem when currency item balance is equal to the purchasable item price